### PR TITLE
Eliminazione menù Posizioni Lavorative

### DIFF
--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -55,13 +55,13 @@
             parent="menu_hr_root"
             groups="hr.group_hr_user"
             sequence="100"/>
-
+<!--
             <menuitem
                 id="menu_view_hr_job"
                 action="action_hr_job"
                 parent="menu_human_resources_configuration"
                 sequence="1"/>
-
+-->
             <menuitem
                 id="menu_human_resources_configuration_employee"
                 name="Employee"
@@ -76,7 +76,7 @@
                     parent="menu_human_resources_configuration_employee"
                     groups="base.group_no_one"
                     sequence="1"/>
-<!--
+
             <menuitem
                 id="menu_hr_department_tree"
                 action="hr_department_tree_action"


### PR DESCRIPTION
Ho nascosto anche l'ultima voce che non volevam nel menù configurazione , inoltre non mi combaciava perfettamente il codice per nascondere i menu sottostanti e l'ho leggermente aggiustato.